### PR TITLE
bug(big-euclidean.rs): remove deprecated time crate

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,4 +19,4 @@ jobs:
         run: docker build --no-cache -t distance .
 
       - name: Unit Tests
-        run: docker run cargo test
+        run: docker run distance cargo test

--- a/examples/big-euclidean.rs
+++ b/examples/big-euclidean.rs
@@ -1,5 +1,4 @@
-extern crate time;
-use time::PreciseTime;
+use std::time::Instant;
 extern crate distance;
 use distance::cosine;
 
@@ -8,10 +7,9 @@ fn main() {
 	let n = 100000000;
     let x: Vec<f64> = vec![0.2; n];
     let y: Vec<f64> = vec![0.3; n];
-    let start = PreciseTime::now();
+    let start = Instant::now();
     let prod = cosine(&x,&y);
-    let end = PreciseTime::now();
-    println!("{}", start.to(end));
+    println!("{}", start.elapsed().as_secs());
     println!("{}", prod);
     // assert!(approx_eq!(f64, prod, 6000000.0, ulps=2));
 }


### PR DESCRIPTION
rely on std::time instead. Should fix Docker stuff.